### PR TITLE
Modify podspec deployment target

### DIFF
--- a/MockingKit.podspec
+++ b/MockingKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'MockingKit'
   s.version          = '0.9.0'
-  s.swift_versions   = ['5.3']
+  s.swift_versions   = ['5.0', '5.3']
   s.summary          = 'MockingKit is a mocking library for Swift.'
   s.description      = 'MockingKit contains protocol mocking utilities for Swift. MockingKit makes it easy to mock protocol implementations for unit tests and to fake functionality in your Swift-based systems.'
 
@@ -10,9 +10,9 @@ Pod::Spec.new do |s|
   s.author           = { 'Daniel Saidi' => 'daniel.saidi@gmail.com' }
   s.source           = { :git => 'https://github.com/danielsaidi/MockingKit.git', :tag => s.version.to_s }
 
-  s.swift_version = '5.3'
-  s.ios.deployment_target = '13.0'
-  s.tvos.deployment_target = '13.0'
+  s.swift_version = '5.0'
+  s.ios.deployment_target = '11.0'
+  s.tvos.deployment_target = '11.0'
   s.macos.deployment_target = '10.10'
   s.watchos.deployment_target = '6.0'
   


### PR DESCRIPTION
I had needs to set the iOS deployment target to version 11 or higher. But it was 13 or higher, so I made PR to make deployment target down to `11 or higher` to make this universal.

In my opinion, supporting more versions will make this great project more accessible to more people.

## BE CAREFUL BEFORE MERGE

* I did run `swift test` and All passed. But I am not sure if there will be another side effect. 
* If you accept this PR, Please check before merge

