### PR TITLE
register result on set functions in MockUserDefaults

### DIFF
--- a/Sources/MockingKit/Foundation/MockUserDefaults.swift
+++ b/Sources/MockingKit/Foundation/MockUserDefaults.swift
@@ -75,22 +75,27 @@ open class MockUserDefaults: UserDefaults, Mockable {
     }
     
     open override func set(_ value: Bool, forKey defaultName: String) {
+        mock.registerResult(for: boolRef) { _ in value }
         mock.call(self.setBoolRef, args: (value, defaultName))
     }
     
     open override func set(_ value: Double, forKey defaultName: String) {
+        mock.registerResult(for: doubleRef) { _ in value }
         mock.call(self.setDoubleRef, args: (value, defaultName))
     }
     
     open override func set(_ value: Float, forKey defaultName: String) {
+        mock.registerResult(for: floatRef) { _ in value }
         mock.call(self.setFloatRef, args: (value, defaultName))
     }
     
     open override func set(_ value: Int, forKey defaultName: String) {
+        mock.registerResult(for: integerRef) { _ in value }
         mock.call(self.setIntegerRef, args: (value, defaultName))
     }
     
     open override func set(_ url: URL?, forKey defaultName: String) {
+        mock.registerResult(for: urlRef) { _ in url }
         mock.call(self.setUrlRef, args: (url, defaultName))
     }
     


### PR DESCRIPTION
**_Hi!_**
Thank you so much for this wonderful framework. Swift cannot be tested in a good way without ut! ❤️

This PR adds a `registerResult` for each `set` method in `MockUserDefaults`. This way the result can be set by the _thing_ that is tested if it calls `defaults.set(value, forKey: key)` and no extra registration is needed. 


