### PR TITLE
Add async support to Mockable

### DIFF
--- a/MockingKit.podspec
+++ b/MockingKit.podspec
@@ -9,11 +9,11 @@ Pod::Spec.new do |s|
   s.license          = { :type => 'NONE', :file => 'LICENSE' }
   s.author           = { 'Daniel Saidi' => 'daniel.saidi@gmail.com' }
   s.source           = { :git => 'https://github.com/danielsaidi/MockingKit.git', :tag => s.version.to_s }
-
-  s.swift_version = '5.0'
-  s.ios.deployment_target = '9.0'
-  s.tvos.deployment_target = '9.0'
-  s.macos.deployment_target = '10.10'
+  
+  s.swift_version = '5.6'
+  s.ios.deployment_target = '13.0'
+  s.tvos.deployment_target = '13.0'
+  s.macos.deployment_target = '10.15'
   s.watchos.deployment_target = '6.0'
   
   s.source_files = 'Sources/MockingKit/**/*.swift'

--- a/Package.swift
+++ b/Package.swift
@@ -1,14 +1,14 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 
 import PackageDescription
 
 let package = Package(
     name: "MockingKit",
     platforms: [
-        .iOS(.v9),
-        .tvOS(.v9),
+        .iOS(.v13),
+        .tvOS(.v13),
         .watchOS(.v6),
-        .macOS(.v10_10)
+        .macOS(.v10_15)
     ],
     products: [
         .library(

--- a/Sources/MockingKit/AsyncMockReference.swift
+++ b/Sources/MockingKit/AsyncMockReference.swift
@@ -1,0 +1,21 @@
+//
+//  AsyncTests.swift
+//
+//  Created by Tobias Boogh on 2022-05-04.
+//
+
+import Foundation
+
+/**
+ This struct is used to get a unique reference to an async function.
+ */
+public struct AsyncMockReference<Arguments, Result>: Identifiable {
+
+    public init(_ function: @escaping (Arguments) async throws -> Result) {
+        self.id = UUID()
+        self.function = function
+    }
+
+    public let id: UUID
+    public let function: (Arguments) async throws -> Result
+}

--- a/Sources/MockingKit/Mockable.swift
+++ b/Sources/MockingKit/Mockable.swift
@@ -48,6 +48,15 @@ public extension Mockable {
         result: @escaping (Arguments) throws -> Result) {
         mock.registeredResults[ref.id] = result
     }
+
+    /**
+     Register a result value for a certain mocked async function.
+     */
+    func registerResult<Arguments, Result>(
+        for ref: AsyncMockReference<Arguments, Result>,
+        result: @escaping (Arguments) async throws -> Result) {
+        mock.registeredResults[ref.id] = result
+    }
 }
 
 
@@ -82,6 +91,34 @@ public extension Mockable {
         registerCall(call, for: ref)
         return result
     }
+
+    /**
+     Call an async function with a `non-optional` result. This will
+     return a pre-registered result or crash if no result is
+     registered.
+    */
+    func call<Arguments, Result>(
+        _ ref: AsyncMockReference<Arguments, Result>,
+        args: Arguments,
+        file: StaticString = #file,
+        line: UInt = #line,
+        functionCall: StaticString = #function) async -> Result {
+
+        if Result.self == Void.self {
+            let void = unsafeBitCast((), to: Result.self)
+            let call = MockCall(arguments: args, result: void)
+            registerCall(call, for: ref)
+            return void
+        }
+
+            guard let result = try? await registeredResult(for: ref)?(args) else {
+            let message = "You must register a result for '\(functionCall)' with `registerResult(for:)` before calling this function."
+            preconditionFailure(message, file: file, line: line)
+        }
+        let call = MockCall(arguments: args, result: result)
+        registerCall(call, for: ref)
+        return result
+    }
     
     /**
      Call a function with a `non-optional` result. This will
@@ -96,6 +133,20 @@ public extension Mockable {
         registerCall(MockCall(arguments: args, result: result), for: ref)
         return result
     }
+
+    /**
+     Call an async function with a `non-optional` result. This will
+     return a pre-registered result or a `fallback` value if
+     no result has been registered.
+    */
+    func call<Arguments, Result>(
+        _ ref: AsyncMockReference<Arguments, Result>,
+        args: Arguments,
+        fallback: @autoclosure () -> Result) async -> Result {
+        let result = (try? await registeredResult(for: ref)?(args)) ?? fallback()
+        registerCall(MockCall(arguments: args, result: result), for: ref)
+        return result
+    }
     
     /**
      Call a function with an `optional` result. This returns
@@ -105,6 +156,18 @@ public extension Mockable {
         _ ref: MockReference<Arguments, Result?>,
         args: Arguments) -> Result? {
         let result = try? registeredResult(for: ref)?(args)
+        registerCall(MockCall(arguments: args, result: result), for: ref)
+        return result
+    }
+
+    /**
+     Call an async function with an `optional` result. This returns
+     a pre-registered result or `nil`.
+    */
+    func call<Arguments, Result>(
+        _ ref: AsyncMockReference<Arguments, Result?>,
+        args: Arguments) async -> Result? {
+        let result = try? await registeredResult(for: ref)?(args)
         registerCall(MockCall(arguments: args, result: result), for: ref)
         return result
     }
@@ -123,6 +186,14 @@ public extension Mockable {
         to ref: MockReference<Arguments, Result>) {
         mock.registeredCalls[ref.id] = []
     }
+
+    /**
+     Reset all registered calls to a certain asnyc function.
+     */
+    func resetCalls<Arguments, Result>(
+        to ref: AsyncMockReference<Arguments, Result>) {
+        mock.registeredCalls[ref.id] = []
+    }
 }
 
 
@@ -137,12 +208,28 @@ public extension Mockable {
         to ref: MockReference<Arguments, Result>) -> [MockCall<Arguments, Result>] {
         registeredCalls(for: ref)
     }
+
+    /**
+     Get all calls to a certain async function.
+     */
+    func calls<Arguments, Result>(
+        to ref: AsyncMockReference<Arguments, Result>) -> [MockCall<Arguments, Result>] {
+        registeredCalls(for: ref)
+    }
     
     /**
      Check if a function has been called.
      */
     func hasCalled<Arguments, Result>(
         _ ref: MockReference<Arguments, Result>) -> Bool {
+        calls(to: ref).count > 0
+    }
+
+    /**
+     Check if an async function has been called.
+     */
+    func hasCalled<Arguments, Result>(
+        _ ref: AsyncMockReference<Arguments, Result>) -> Bool {
         calls(to: ref).count > 0
     }
     
@@ -153,16 +240,31 @@ public extension Mockable {
         _ ref: MockReference<Arguments, Result>, numberOfTimes: Int) -> Bool {
         calls(to: ref).count == numberOfTimes
     }
+
+    /**
+     Check if an async function has been called a number of times.
+     */
+    func hasCalled<Arguments, Result>(
+        _ ref: AsyncMockReference<Arguments, Result>, numberOfTimes: Int) -> Bool {
+        calls(to: ref).count == numberOfTimes
+    }
 }
 
 
 // MARK: - Private Functions
 
 private extension Mockable {
-    
+
     func registerCall<Arguments, Result>(
         _ call: MockCall<Arguments, Result>,
         for ref: MockReference<Arguments, Result>) {
+        let calls = mock.registeredCalls[ref.id] ?? []
+        mock.registeredCalls[ref.id] = calls + [call]
+    }
+
+    func registerCall<Arguments, Result>(
+        _ call: MockCall<Arguments, Result>,
+        for ref: AsyncMockReference<Arguments, Result>) {
         let calls = mock.registeredCalls[ref.id] ?? []
         mock.registeredCalls[ref.id] = calls + [call]
     }
@@ -172,9 +274,20 @@ private extension Mockable {
         let calls = mock.registeredCalls[ref.id]
         return (calls as? [MockCall<Arguments, Result>]) ?? []
     }
-    
+
+    func registeredCalls<Arguments, Result>(
+        for ref: AsyncMockReference<Arguments, Result>) -> [MockCall<Arguments, Result>] {
+        let calls = mock.registeredCalls[ref.id]
+        return (calls as? [MockCall<Arguments, Result>]) ?? []
+    }
+
     func registeredResult<Arguments, Result>(
         for ref: MockReference<Arguments, Result>) -> ((Arguments) throws -> Result)? {
         mock.registeredResults[ref.id] as? (Arguments) throws -> Result
+    }
+
+    func registeredResult<Arguments, Result>(
+        for ref: AsyncMockReference<Arguments, Result>) -> ((Arguments) async throws -> Result)? {
+        mock.registeredResults[ref.id] as? (Arguments) async throws -> Result
     }
 }

--- a/Tests/MockingKitTests/MockableAsyncTests.swift
+++ b/Tests/MockingKitTests/MockableAsyncTests.swift
@@ -1,0 +1,295 @@
+//
+//  MockableAsyncTests.swift
+//
+//  Created by Tobias Boogh on 2022-05-04.
+//
+
+import XCTest
+import Nimble
+@testable import MockingKit
+
+class MockableAsyncTests: XCTestCase {
+
+    fileprivate var mock: TestClass!
+
+    override func setUp() {
+        mock = TestClass()
+    }
+
+    func testRegisteringResult_registersFunctionWithReferenceId() {
+        let ref = mock.functionWithIntResultRef
+        let result: (String, Int) throws -> Int = { _, int in int * 2 }
+        mock.registerResult(for: ref, result: result)
+        let obj = mock.mock.registeredResults[ref.id]
+        expect(obj).toNot(beNil())
+    }
+
+    func testCallingAFunctionWithNonOptionalResult_itSupportsDifferentResultTypes() async {
+
+        let user = User(name: "a user")
+        let thing = Thing(name: "a thing")
+        mock.registerResult(for: mock.functionWithIntResultRef) { _ in 123 }
+        mock.registerResult(for: mock.functionWithStringResultRef) { _ in "a string" }
+        mock.registerResult(for: mock.functionWithStructResultRef) { _ in user }
+        mock.registerResult(for: mock.functionWithClassResultRef) { _ in thing }
+
+        let intResult = await mock.functionWithIntResult(arg1: "abc", arg2: 123)
+        let stringResult = await mock.functionWithStringResult(arg1: "abc", arg2: 123)
+        let structResult = await mock.functionWithStructResult(arg1: "abc", arg2: 123)
+        let classResult = await mock.functionWithClassResult(arg1: "abc", arg2: 123)
+
+        expect(intResult).to(equal(123))
+        expect(stringResult).to(equal("a string"))
+        expect(structResult).to(equal(user))
+        expect(classResult).to(be(thing))
+    }
+
+    func testCallingAFunctionWithNonOptionalResult_itCanRegisterDifferentReturnValuesForDifferentArgumentValues() async {
+        mock.registerResult(for: mock.functionWithIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: mock.functionWithStringResultRef) { arg1, _ in arg1 }
+
+        let intResult = await mock.functionWithIntResult(arg1: "abc", arg2: 123)
+        let int2Result = await mock.functionWithIntResult(arg1: "abc", arg2: 456)
+        let stringResult = await mock.functionWithStringResult(arg1: "abc", arg2: 123)
+        let string2Result = await mock.functionWithStringResult(arg1: "def", arg2: 123)
+
+        expect(intResult).to(equal(123))
+        expect(int2Result).to(equal(456))
+        expect(stringResult).to(equal("abc"))
+        expect(string2Result).to(equal("def"))
+    }
+
+    func testCallingAFunctionWithNonOptionalResult_itRegistersCalls() async {
+        mock.registerResult(for: mock.functionWithIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: mock.functionWithStringResultRef) { arg1, _ in arg1 }
+
+        _ = await mock.functionWithIntResult(arg1: "abc", arg2: 123)
+        _ = await mock.functionWithIntResult(arg1: "abc", arg2: 456)
+        _ = await mock.functionWithIntResult(arg1: "abc", arg2: 789)
+        _ = await mock.functionWithStringResult(arg1: "abc", arg2: 123)
+        _ = await mock.functionWithStringResult(arg1: "def", arg2: 123)
+
+        let intCalls = mock.calls(to: mock.functionWithIntResultRef)
+        let strCalls = mock.calls(to: mock.functionWithStringResultRef)
+        expect(intCalls.count).to(equal(3))
+        expect(strCalls.count).to(equal(2))
+        expect(intCalls[0].arguments.0).to(equal("abc"))
+        expect(intCalls[0].arguments.1).to(equal(123))
+        expect(intCalls[1].arguments.0).to(equal("abc"))
+        expect(intCalls[1].arguments.1).to(equal(456))
+        expect(intCalls[2].arguments.0).to(equal("abc"))
+        expect(intCalls[2].arguments.1).to(equal(789))
+        expect(strCalls[0].arguments.0).to(equal("abc"))
+        expect(strCalls[0].arguments.1).to(equal(123))
+        expect(strCalls[1].arguments.0).to(equal("def"))
+        expect(strCalls[1].arguments.1).to(equal(123))
+    }
+
+    func testCallingAFunctionWithOptionalResult_doesNotFailWithPreconditionFailureIfNoResultIsRegistered() async {
+        let intResult = await mock.functionWithOptionalIntResult(arg1: "abc", arg2: 123)
+        let stringResult = await mock.functionWithOptionalStringResult(arg1: "abc", arg2: 123)
+        let structResult = await mock.functionWithOptionalStructResult(arg1: "abc", arg2: 123)
+        let classResult = await mock.functionWithOptionalClassResult(arg1: "abc", arg2: 123)
+
+        expect(intResult).to(beNil())
+        expect(stringResult).to(beNil())
+        expect(structResult).to(beNil())
+        expect(classResult).to(beNil())
+    }
+
+    func testCallingAFunctionWithOptionalResult_itSupportsDifferentResultTypes() async {
+        let user = User(name: "a user")
+        let thing = Thing(name: "a thing")
+        mock.registerResult(for: mock.functionWithOptionalIntResultRef) { _ in 123 }
+        mock.registerResult(for: mock.functionWithOptionalStringResultRef) { _ in "a string" }
+        mock.registerResult(for: mock.functionWithOptionalStructResultRef) { _ in user }
+        mock.registerResult(for: mock.functionWithOptionalClassResultRef) { _ in thing }
+
+        let intResult = await mock.functionWithOptionalIntResult(arg1: "abc", arg2: 123)
+        let stringResult = await mock.functionWithOptionalStringResult(arg1: "abc", arg2: 123)
+        let structResult = await mock.functionWithOptionalStructResult(arg1: "abc", arg2: 123)
+        let classResult = await mock.functionWithOptionalClassResult(arg1: "abc", arg2: 123)
+
+        expect(intResult).to(equal(123))
+        expect(stringResult).to(equal("a string"))
+        expect(structResult).to(equal(user))
+        expect(classResult).to(be(thing))
+    }
+
+    func testCallingAFunctionWithOptionalResult_itCanRegisterDifferentReturnValuesForDifferentArgumentValues() async {
+        mock.registerResult(for: mock.functionWithOptionalIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: mock.functionWithOptionalStringResultRef) { arg1, _ in arg1 }
+
+        let intResult = await mock.functionWithOptionalIntResult(arg1: "abc", arg2: 123)
+        let int2Result = await mock.functionWithOptionalIntResult(arg1: "abc", arg2: 456)
+        let stringResult = await mock.functionWithOptionalStringResult(arg1: "abc", arg2: 123)
+        let string2Result = await mock.functionWithOptionalStringResult(arg1: "def", arg2: 123)
+
+        expect(intResult).to(equal(123))
+        expect(int2Result).to(equal(456))
+        expect(stringResult).to(equal("abc"))
+        expect(string2Result).to(equal("def"))
+    }
+    func testCallingAFunctionWithOptionalResult_itRegistersCalls() async {
+        mock.registerResult(for: mock.functionWithOptionalIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: mock.functionWithOptionalStringResultRef) { arg1, _ in arg1 }
+
+        _ = await mock.functionWithOptionalIntResult(arg1: "abc", arg2: 123)
+        _ = await mock.functionWithOptionalIntResult(arg1: "abc", arg2: 456)
+        _ = await mock.functionWithOptionalIntResult(arg1: "abc", arg2: 789)
+        _ = await mock.functionWithOptionalStringResult(arg1: "abc", arg2: 123)
+        _ = await mock.functionWithOptionalStringResult(arg1: "def", arg2: 123)
+
+        let intCalls = mock.calls(to: mock.functionWithOptionalIntResultRef)
+        let strCalls = mock.calls(to: mock.functionWithOptionalStringResultRef)
+        expect(intCalls.count).to(equal(3))
+        expect(strCalls.count).to(equal(2))
+        expect(intCalls[0].arguments.0).to(equal("abc"))
+        expect(intCalls[0].arguments.1).to(equal(123))
+        expect(intCalls[1].arguments.0).to(equal("abc"))
+        expect(intCalls[1].arguments.1).to(equal(456))
+        expect(intCalls[2].arguments.0).to(equal("abc"))
+        expect(intCalls[2].arguments.1).to(equal(789))
+        expect(strCalls[0].arguments.0).to(equal("abc"))
+        expect(strCalls[0].arguments.1).to(equal(123))
+        expect(strCalls[1].arguments.0).to(equal("def"))
+        expect(strCalls[1].arguments.1).to(equal(123))
+    }
+
+    func testCallingAFunctionWithFallback_ReturnsDefaultValueIfNoValueIsRegistered() async {
+        let intResult = await mock.call(self.mock.functionWithIntResultRef, args: ("abc", 123), fallback: 456)
+        let stringResult = await mock.call(self.mock.functionWithStringResultRef, args: ("abc", 123), fallback: "def")
+
+        expect(intResult).to(equal(456))
+        expect(stringResult).to(equal("def"))
+    }
+
+    func testCallingAFunctionWithFallback_ReturnsRegisteredValueIfAValueIsRegistered() async {
+        self.mock.registerResult(for: self.mock.functionWithIntResultRef) { _ in 123 }
+        self.mock.registerResult(for: self.mock.functionWithStringResultRef) { _ in "a string" }
+
+        let intResult = await mock.call(self.mock.functionWithIntResultRef, args: ("abc", 123), fallback: 456)
+        let stringResult = await mock.call(self.mock.functionWithStringResultRef, args: ("abc", 123), fallback: "def")
+
+        expect(intResult).to(equal(123))
+        expect(stringResult).to(equal("a string"))
+    }
+
+    func testCallingAFunctionWithVoidResult_doesNotFailWithPreconditionFailureIfNoResultIsRegistered() async {
+        await mock.functionWithVoidResult(arg1: "abc", arg2: 123)
+    }
+
+    func testCallingAFunctionWithVoidResult_itRegistersCalls() async {
+        mock.registerResult(for: mock.functionWithOptionalIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: mock.functionWithOptionalStringResultRef) { arg1, _ in arg1 }
+
+        await mock.functionWithVoidResult(arg1: "abc", arg2: 123)
+        await mock.functionWithVoidResult(arg1: "abc", arg2: 456)
+        await mock.functionWithVoidResult(arg1: "abc", arg2: 789)
+
+        let calls = mock.calls(to: mock.functionWithVoidResultRef)
+        expect(calls.count).to(equal(3))
+        expect(calls[0].arguments.0).to(equal("abc"))
+        expect(calls[0].arguments.1).to(equal(123))
+        expect(calls[1].arguments.0).to(equal("abc"))
+        expect(calls[1].arguments.1).to(equal(456))
+        expect(calls[2].arguments.0).to(equal("abc"))
+        expect(calls[2].arguments.1).to(equal(789))
+    }
+
+
+    func testInspectingCalls_RegistersAllCalls() async {
+        await mock.functionWithVoidResult(arg1: "abc", arg2: 123)
+        await mock.functionWithVoidResult(arg1: "abc", arg2: 456)
+        await mock.functionWithVoidResult(arg1: "abc", arg2: 789)
+        let calls = mock.calls(to: mock.functionWithVoidResultRef)
+        expect(calls.count).to(equal(3))
+    }
+
+    func testInspectingCalls_canVerifyIfAtLeastOneCallHasBeenMade() async {
+        expect(self.mock.hasCalled(self.mock.functionWithVoidResultRef)).to(beFalse())
+        await mock.functionWithVoidResult(arg1: "abc", arg2: 123)
+        expect(self.mock.hasCalled(self.mock.functionWithVoidResultRef)).to(beTrue())
+        await mock.functionWithVoidResult(arg1: "abc", arg2: 456)
+        expect(self.mock.hasCalled(self.mock.functionWithVoidResultRef)).to(beTrue())
+    }
+
+    func testInspectingCalls_CanVerifyIfAnExactNumberOrCallsHaveBeenMade() async {
+        expect(self.mock.hasCalled(self.mock.functionWithVoidResultRef, numberOfTimes: 2)).to(beFalse())
+        await mock.functionWithVoidResult(arg1: "abc", arg2: 123)
+        expect(self.mock.hasCalled(self.mock.functionWithVoidResultRef, numberOfTimes: 2)).to(beFalse())
+        await mock.functionWithVoidResult(arg1: "abc", arg2: 456)
+        expect(self.mock.hasCalled(self.mock.functionWithVoidResultRef, numberOfTimes: 2)).to(beTrue())
+    }
+
+    func testResettingCalls_CanResetAllCalls() async {
+        mock.registerResult(for: mock.functionWithIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: mock.functionWithStringResultRef) { arg1, _ in arg1 }
+        _ = await mock.functionWithIntResult(arg1: "abc", arg2: 123)
+        _ = await mock.functionWithStringResult(arg1: "abc", arg2: 123)
+        mock.resetCalls()
+        expect(self.mock.hasCalled(self.mock.functionWithIntResultRef)).to(beFalse())
+        expect(self.mock.hasCalled(self.mock.functionWithStringResultRef)).to(beFalse())
+    }
+
+    func testResettingCalls_canResetAllCallsForACertainFunction() async {
+        mock.registerResult(for: mock.functionWithIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: mock.functionWithStringResultRef) { arg1, _ in arg1 }
+        _ = await mock.functionWithIntResult(arg1: "abc", arg2: 123)
+        _ = await mock.functionWithStringResult(arg1: "abc", arg2: 123)
+        mock.resetCalls(to: mock.functionWithIntResultRef)
+        expect(self.mock.hasCalled(self.mock.functionWithIntResultRef)).to(beFalse())
+        expect(self.mock.hasCalled(self.mock.functionWithStringResultRef)).to(beTrue())
+    }
+}
+private class TestClass: AsyncTestProtocol, Mockable {
+
+    var mock = Mock()
+
+    lazy var functionWithIntResultRef = AsyncMockReference(functionWithIntResult)
+    lazy var functionWithStringResultRef = AsyncMockReference(functionWithStringResult)
+    lazy var functionWithStructResultRef = AsyncMockReference(functionWithStructResult)
+    lazy var functionWithClassResultRef = AsyncMockReference(functionWithClassResult)
+    lazy var functionWithOptionalIntResultRef = AsyncMockReference(functionWithOptionalIntResult)
+    lazy var functionWithOptionalStringResultRef = AsyncMockReference(functionWithOptionalStringResult)
+    lazy var functionWithOptionalStructResultRef = AsyncMockReference(functionWithOptionalStructResult)
+    lazy var functionWithOptionalClassResultRef = AsyncMockReference(functionWithOptionalClassResult)
+    lazy var functionWithVoidResultRef = AsyncMockReference(functionWithVoidResult)
+
+    func functionWithIntResult(arg1: String, arg2: Int) async -> Int {
+        await call(functionWithIntResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithStringResult(arg1: String, arg2: Int) async -> String {
+        await call(functionWithStringResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithStructResult(arg1: String, arg2: Int) async -> User {
+        await call(functionWithStructResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithClassResult(arg1: String, arg2: Int) async -> Thing {
+        await call(functionWithClassResultRef, args: (arg1, arg2))
+    }
+
+
+    func functionWithOptionalIntResult(arg1: String, arg2: Int) async -> Int? {
+        await call(functionWithOptionalIntResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithOptionalStringResult(arg1: String, arg2: Int) async -> String? {
+        await call(functionWithOptionalStringResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithOptionalStructResult(arg1: String, arg2: Int) async -> User? {
+        await call(functionWithOptionalStructResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithOptionalClassResult(arg1: String, arg2: Int) async -> Thing? {
+        await call(functionWithOptionalClassResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithVoidResult(arg1: String, arg2: Int) async {
+        await call(functionWithVoidResultRef, args: (arg1, arg2))
+    }
+}

--- a/Tests/MockingKitTests/TestTypes.swift
+++ b/Tests/MockingKitTests/TestTypes.swift
@@ -25,6 +25,21 @@ protocol TestProtocol {
     func asyncFunction(arg1: String, completion: @escaping (Error?) -> Void)
 }
 
+protocol AsyncTestProtocol {
+
+    func functionWithIntResult(arg1: String, arg2: Int) async -> Int
+    func functionWithStringResult(arg1: String, arg2: Int) async -> String
+    func functionWithStructResult(arg1: String, arg2: Int) async -> User
+    func functionWithClassResult(arg1: String, arg2: Int) async -> Thing
+
+    func functionWithOptionalIntResult(arg1: String, arg2: Int) async -> Int?
+    func functionWithOptionalStringResult(arg1: String, arg2: Int) async -> String?
+    func functionWithOptionalStructResult(arg1: String, arg2: Int) async -> User?
+    func functionWithOptionalClassResult(arg1: String, arg2: Int) async -> Thing?
+
+    func functionWithVoidResult(arg1: String, arg2: Int) async
+}
+
 struct User: Equatable {
     
     var name: String


### PR DESCRIPTION
This adds support for async to `Mockable` by adding a `AsyncMockReference` that can take in an async function.

For the tests i just ported the current mockable tests and rewrote them using `XCTestCase` since `Quick` isn't concurrency friendly.

This solves #14 