### PR TITLE
Make access to Mock thread safe

### DIFF
--- a/Sources/MockingKit/Mock.swift
+++ b/Sources/MockingKit/Mock.swift
@@ -16,7 +16,7 @@ import Foundation
 ///
 /// Inherit this type instead of implementing the ``Mockable``
 /// protocol, to save some code for every mock you create.
-open class Mock: Mockable {
+open class Mock: Mockable, @unchecked Sendable {
     
     public init() {}
     

--- a/Sources/MockingKit/Mock.swift
+++ b/Sources/MockingKit/Mock.swift
@@ -24,4 +24,5 @@ open class Mock: Mockable, @unchecked Sendable {
     
     var registeredCalls: [UUID: [AnyCall]] = [:]
     var registeredResults: [UUID: Function] = [:]
+    let registeredCallsLock = NSLock()
 }

--- a/Sources/MockingKit/Mockable.swift
+++ b/Sources/MockingKit/Mockable.swift
@@ -38,41 +38,55 @@ extension Mockable {
         _ call: MockCall<Arguments, Result>,
         for ref: MockReference<Arguments, Result>
     ) {
-        let calls = mock.registeredCalls[ref.id] ?? []
-        mock.registeredCalls[ref.id] = calls + [call]
+        mock.registeredCallsLock.withLock {
+            let calls = mock.registeredCalls[ref.id] ?? []
+            mock.registeredCalls[ref.id] = calls + [call]
+        }
     }
 
     func registerCall<Arguments, Result>(
         _ call: MockCall<Arguments, Result>,
         for ref: AsyncMockReference<Arguments, Result>
     ) {
-        let calls = mock.registeredCalls[ref.id] ?? []
-        mock.registeredCalls[ref.id] = calls + [call]
+        mock.registeredCallsLock.withLock {
+            let calls = mock.registeredCalls[ref.id] ?? []
+            mock.registeredCalls[ref.id] = calls + [call]
+        }
     }
     
     func registeredCalls<Arguments, Result>(
         for ref: MockReference<Arguments, Result>
     ) -> [MockCall<Arguments, Result>] {
-        let calls = mock.registeredCalls[ref.id]
-        return (calls as? [MockCall<Arguments, Result>]) ?? []
+        mock.registeredCallsLock.withLock {
+            let calls = mock.registeredCalls[ref.id]
+            return (calls as? [MockCall<Arguments, Result>]) ?? []
+        }
     }
 
     func registeredCalls<Arguments, Result>(
         for ref: AsyncMockReference<Arguments, Result>
     ) -> [MockCall<Arguments, Result>] {
-        let calls = mock.registeredCalls[ref.id]
-        return (calls as? [MockCall<Arguments, Result>]) ?? []
+        mock.registeredCallsLock.withLock {
+            let calls = mock.registeredCalls[ref.id]
+            return (calls as? [MockCall<Arguments, Result>]) ?? []
+        }
     }
 
     func registeredResult<Arguments, Result>(
         for ref: MockReference<Arguments, Result>
     ) -> ((Arguments) throws -> Result)? {
-        mock.registeredResults[ref.id] as? (Arguments) throws -> Result
+        mock.registeredCallsLock.withLock {
+            let result = mock.registeredResults[ref.id] as? (Arguments) throws -> Result
+            return result
+        }
     }
 
     func registeredResult<Arguments, Result>(
         for ref: AsyncMockReference<Arguments, Result>
     ) -> ((Arguments) async throws -> Result)? {
-        mock.registeredResults[ref.id] as? (Arguments) async throws -> Result
+        mock.registeredCallsLock.withLock {
+            let result = mock.registeredResults[ref.id] as? (Arguments) async throws -> Result
+            return result
+        }
     }
 }

--- a/Sources/MockingKit/Mockable.swift
+++ b/Sources/MockingKit/Mockable.swift
@@ -22,7 +22,7 @@ import Foundation
 ///
 /// Implement this protocol instead of inheriting the ``Mock``
 /// base class, to save some code for every mock you create.
-public protocol Mockable {
+public protocol Mockable: Sendable {
     
     typealias Function = Any
     

--- a/Sources/MockingKit/Mocks/MockPasteboard.swift
+++ b/Sources/MockingKit/Mocks/MockPasteboard.swift
@@ -32,7 +32,7 @@ import AppKit
  This mock only mocks `setValue(_:forKey:)` for now, but you
  can subclass this class and mock more functionality.
  */
-public class MockPasteboard: NSPasteboard, Mockable {
+public class MockPasteboard: NSPasteboard, Mockable, @unchecked Sendable {
 
     public lazy var setValueForKeyRef = MockReference(setValueForKey)
 

--- a/Sources/MockingKit/Mocks/MockUserDefaults.swift
+++ b/Sources/MockingKit/Mocks/MockUserDefaults.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// This class can be used to mock `UserDefaults`.
-open class MockUserDefaults: UserDefaults, Mockable {
+open class MockUserDefaults: UserDefaults, Mockable, @unchecked Sendable {
     
     public lazy var boolRef = MockReference(bool)
     public lazy var arrayRef = MockReference(array)

--- a/Tests/MockingKitTests/GenericTests.swift
+++ b/Tests/MockingKitTests/GenericTests.swift
@@ -21,7 +21,7 @@ final class GenericTests: XCTestCase {
     }
 }
 
-private class GenericMock<T>: Mock {
+private class GenericMock<T>: Mock, @unchecked Sendable {
     
     lazy var doitRef = MockReference(doit)
     


### PR DESCRIPTION
This is a proposal to make the access to the `Mock` thread safe so that it can be used in tests read/write mocks concurrently. The `NSLock` ensures that access to the calls dictionary is safe. We have used a similar approach where we used a `dispatch_semaphore` but `NSLock` feels like it's a cleaner approach. This should solve the problems discussed in issue #20.

The test written is a quick an dirty way to replicate the issue in a minimal way.