### PR TITLE
Adding structs for Throwing Mock References

### DIFF
--- a/Sources/MockingKit/AsyncMockReference.swift
+++ b/Sources/MockingKit/AsyncMockReference.swift
@@ -11,6 +11,12 @@ import Foundation
 /// This type can be used to create mock function references.
 public struct AsyncMockReference<Arguments, Result>: Identifiable {
 
+    public init(_ function: @escaping (Arguments) async -> Result) {
+        self.id = UUID()
+        self.function = function
+    }
+
+    @available(*, deprecated, message: "Use AsyncThrowingMockReference for async throwing functions.")
     public init(_ function: @escaping (Arguments) async throws -> Result) {
         self.id = UUID()
         self.function = function

--- a/Sources/MockingKit/AsyncThrowingMockReference.swift
+++ b/Sources/MockingKit/AsyncThrowingMockReference.swift
@@ -1,0 +1,20 @@
+//
+//  AsyncThrowingMockReference.swift
+//  MockingKit
+//
+//  Created by Sebastiano Zane on 25/05/2026.
+//
+
+import Foundation
+
+/// This type can be used to create mock function references.
+public struct AsyncThrowingMockReference<Arguments, Result>: Identifiable {
+
+    public init(_ function: @escaping (Arguments) async throws -> Result) {
+        self.id = UUID()
+        self.function = function
+    }
+
+    public let id: UUID
+    public let function: (Arguments) async throws -> Result
+}

--- a/Sources/MockingKit/MockReference.swift
+++ b/Sources/MockingKit/MockReference.swift
@@ -11,6 +11,12 @@ import Foundation
 /// This type can be used to create mock function references.
 public struct MockReference<Arguments, Result>: Identifiable {
     
+    public init(_ function: @escaping (Arguments) -> Result) {
+        self.id = UUID()
+        self.function = function
+    }
+
+    @available(*, deprecated, message: "Use ThrowingMockReference for throwing functions.")
     public init(_ function: @escaping (Arguments) throws -> Result) {
         self.id = UUID()
         self.function = function

--- a/Sources/MockingKit/Mockable+Call.swift
+++ b/Sources/MockingKit/Mockable+Call.swift
@@ -72,6 +72,72 @@ public extension Mockable {
 
     /// Call a mock reference with a `non-optional` result.
     ///
+    /// This will return any pre-registered result, or crash if no result is registered.
+    ///
+    /// - Parameters:
+    ///   - ref: The mock reference to call.
+    ///   - args: The arguments to call the functions with.
+    func call<Arguments, Result>(
+        _ ref: ThrowingMockReference<Arguments, Result>,
+        args: Arguments,
+        file: StaticString = #file,
+        line: UInt = #line,
+        functionCall: StaticString = #function
+    ) throws -> Result {
+        guard let registeredResult = registeredResult(for: ref) else {
+            if Result.self == Void.self {
+                let void = unsafeBitCast((), to: Result.self)
+                let call = MockCall(arguments: args, result: void)
+                registerCall(call, for: ref)
+                return void
+            }
+
+            let message = "You must register a result for '\(functionCall)' "
+            + "with `registerResult(for:)` before calling this function."
+            preconditionFailure(message, file: file, line: line)
+        }
+
+        let result = try registeredResult(args)
+        let call = MockCall(arguments: args, result: result)
+        registerCall(call, for: ref)
+        return result
+    }
+
+    /// Call a mock reference with a `non-optional` result.
+    ///
+    /// This will return any pre-registered result, or crash if no result is registered.
+    ///
+    /// - Parameters:
+    ///   - ref: The mock reference to call.
+    ///   - args: The arguments to call the functions with.
+    func call<Arguments, Result>(
+        _ ref: AsyncThrowingMockReference<Arguments, Result>,
+        args: Arguments,
+        file: StaticString = #file,
+        line: UInt = #line,
+        functionCall: StaticString = #function
+    ) async throws -> Result {
+        guard let registeredResult = registeredResult(for: ref) else {
+            if Result.self == Void.self {
+                let void = unsafeBitCast((), to: Result.self)
+                let call = MockCall(arguments: args, result: void)
+                registerCall(call, for: ref)
+                return void
+            }
+
+            let message = "You must register a result for '\(functionCall)' "
+            + "with `registerResult(for:)` before calling this function."
+            preconditionFailure(message, file: file, line: line)
+        }
+
+        let result = try await registeredResult(args)
+        let call = MockCall(arguments: args, result: result)
+        registerCall(call, for: ref)
+        return result
+    }
+
+    /// Call a mock reference with a `non-optional` result.
+    ///
     /// This will return any pre-registered result, else the provided `fallback`.
     ///
     /// - Parameters:
@@ -106,6 +172,42 @@ public extension Mockable {
         return result
     }
 
+    /// Call a mock reference with a `non-optional` result.
+    ///
+    /// This will return any pre-registered result, else the provided `fallback`.
+    ///
+    /// - Parameters:
+    ///   - ref: The mock reference to call.
+    ///   - args: The arguments to call the functions with.
+    ///   - fallback: The value to return if no result has been registered.
+    func call<Arguments, Result>(
+        _ ref: ThrowingMockReference<Arguments, Result>,
+        args: Arguments,
+        fallback: @autoclosure () -> Result
+    ) throws -> Result {
+        let result = try registeredResult(for: ref)?(args) ?? fallback()
+        registerCall(MockCall(arguments: args, result: result), for: ref)
+        return result
+    }
+
+    /// Call a mock reference with a `non-optional` result.
+    ///
+    /// This will return any pre-registered result, else the provided `fallback`.
+    ///
+    /// - Parameters:
+    ///   - ref: The mock reference to call.
+    ///   - args: The arguments to call the functions with.
+    ///   - fallback: The value to return if no result has been registered.
+    func call<Arguments, Result>(
+        _ ref: AsyncThrowingMockReference<Arguments, Result>,
+        args: Arguments,
+        fallback: @autoclosure () -> Result
+    ) async throws -> Result {
+        let result = try await registeredResult(for: ref)?(args) ?? fallback()
+        registerCall(MockCall(arguments: args, result: result), for: ref)
+        return result
+    }
+
     /// Call a mock reference with an `optional` result.
     ///
     /// This will return any pre-registered result, else `nil`.
@@ -134,6 +236,38 @@ public extension Mockable {
         args: Arguments
     ) async -> Result? {
         let result = try? await registeredResult(for: ref)?(args)
+        registerCall(MockCall(arguments: args, result: result), for: ref)
+        return result
+    }
+
+    /// Call a mock reference with an `optional` result.
+    ///
+    /// This will return any pre-registered result, else `nil`.
+    ///
+    /// - Parameters:
+    ///   - ref: The mock reference to call.
+    ///   - args: The arguments to call the functions with.
+    func call<Arguments, Result>(
+        _ ref: ThrowingMockReference<Arguments, Result?>,
+        args: Arguments
+    ) throws -> Result? {
+        let result = try registeredResult(for: ref)?(args)
+        registerCall(MockCall(arguments: args, result: result), for: ref)
+        return result
+    }
+
+    /// Call a mock reference with an `optional` result.
+    ///
+    /// This will return any pre-registered result, else `nil`.
+    ///
+    /// - Parameters:
+    ///   - ref: The mock reference to call.
+    ///   - args: The arguments to call the functions with.
+    func call<Arguments, Result>(
+        _ ref: AsyncThrowingMockReference<Arguments, Result?>,
+        args: Arguments
+    ) async throws -> Result? {
+        let result = try await registeredResult(for: ref)?(args)
         registerCall(MockCall(arguments: args, result: result), for: ref)
         return result
     }

--- a/Sources/MockingKit/Mockable+Inspect.swift
+++ b/Sources/MockingKit/Mockable+Inspect.swift
@@ -50,6 +50,46 @@ public extension Mockable {
         calls(to: self[keyPath: refKeyPath])
     }
 
+    /// Get all calls to a certain mock reference.
+    ///
+    /// - Parameters:
+    ///   - ref: The mock reference to check calls for.
+    func calls<Arguments, Result>(
+        to ref: ThrowingMockReference<Arguments, Result>
+    ) -> [MockCall<Arguments, Result>] {
+        registeredCalls(for: ref)
+    }
+
+    /// Get all calls to a certain mock reference.
+    ///
+    /// - Parameters:
+    ///   - refKeyPath: A key path to the mock reference to check calls for.
+    func calls<Arguments, Result>(
+        to refKeyPath: KeyPath<Self, ThrowingMockReference<Arguments, Result>>
+    ) -> [MockCall<Arguments, Result>] {
+        calls(to: self[keyPath: refKeyPath])
+    }
+
+    /// Get all calls to a certain async mock reference.
+    ///
+    /// - Parameters:
+    ///   - ref: The mock reference to check calls for.
+    func calls<Arguments, Result>(
+        to ref: AsyncThrowingMockReference<Arguments, Result>
+    ) -> [MockCall<Arguments, Result>] {
+        registeredCalls(for: ref)
+    }
+
+    /// Get all calls to a certain async mock reference.
+    ///
+    /// - Parameters:
+    ///   - refKeyPath: A key path to the mock reference to check calls for.
+    func calls<Arguments, Result>(
+        to refKeyPath: KeyPath<Self, AsyncThrowingMockReference<Arguments, Result>>
+    ) -> [MockCall<Arguments, Result>] {
+        calls(to: self[keyPath: refKeyPath])
+    }
+
     /// Check if a mock reference has been called.
     ///
     /// - Parameters:
@@ -86,6 +126,46 @@ public extension Mockable {
     ///   - refKeyPath: A key path to the mock reference to check calls for.
     func hasCalled<Arguments, Result>(
         _ refKeyPath: KeyPath<Self, AsyncMockReference<Arguments, Result>>
+    ) -> Bool {
+        hasCalled(self[keyPath: refKeyPath])
+    }
+
+    /// Check if a mock reference has been called.
+    ///
+    /// - Parameters:
+    ///   - ref: The mock reference to check calls for.
+    func hasCalled<Arguments, Result>(
+        _ ref: ThrowingMockReference<Arguments, Result>
+    ) -> Bool {
+        calls(to: ref).count > 0
+    }
+
+    /// Check if a mock reference has been called.
+    ///
+    /// - Parameters:
+    ///   - refKeyPath: A key path to the mock reference to check calls for.
+    func hasCalled<Arguments, Result>(
+        _ refKeyPath: KeyPath<Self, ThrowingMockReference<Arguments, Result>>
+    ) -> Bool {
+        hasCalled(self[keyPath: refKeyPath])
+    }
+
+    /// Check if an async mock reference has been called.
+    ///
+    /// - Parameters:
+    ///   - ref: The mock reference to check calls for.
+    func hasCalled<Arguments, Result>(
+        _ ref: AsyncThrowingMockReference<Arguments, Result>
+    ) -> Bool {
+        calls(to: ref).count > 0
+    }
+
+    /// Check if an async mock reference has been called.
+    ///
+    /// - Parameters:
+    ///   - refKeyPath: A key path to the mock reference to check calls for.
+    func hasCalled<Arguments, Result>(
+        _ refKeyPath: KeyPath<Self, AsyncThrowingMockReference<Arguments, Result>>
     ) -> Bool {
         hasCalled(self[keyPath: refKeyPath])
     }
@@ -139,6 +219,62 @@ public extension Mockable {
     ///   - refKeyPath: A key path to the mock reference to check calls for.
     func hasCalled<Arguments, Result>(
         _ refKeyPath: KeyPath<Self, AsyncMockReference<Arguments, Result>>,
+        numberOfTimes: Int
+    ) -> Bool {
+        hasCalled(self[keyPath: refKeyPath], numberOfTimes: numberOfTimes)
+    }
+
+    /// Check if a mock reference has been called.
+    ///
+    /// For this function to return `true` the actual number
+    /// of calls must match the provided `numberOfCalls`.
+    ///
+    /// - Parameters:
+    ///   - ref: The mock reference to check calls for.
+    func hasCalled<Arguments, Result>(
+        _ ref: ThrowingMockReference<Arguments, Result>,
+        numberOfTimes: Int
+    ) -> Bool {
+        calls(to: ref).count == numberOfTimes
+    }
+
+    /// Check if a mock reference has been called.
+    ///
+    /// For this function to return `true` the actual number
+    /// of calls must match the provided `numberOfCalls`.
+    ///
+    /// - Parameters:
+    ///   - refKeyPath: A key path to the mock reference to check calls for.
+    func hasCalled<Arguments, Result>(
+        _ refKeyPath: KeyPath<Self, ThrowingMockReference<Arguments, Result>>,
+        numberOfTimes: Int
+    ) -> Bool {
+        hasCalled(self[keyPath: refKeyPath], numberOfTimes: numberOfTimes)
+    }
+
+    /// Check if an async mock reference has been called.
+    ///
+    /// For this function to return `true` the actual number
+    /// of calls must match the provided `numberOfCalls`.
+    ///
+    /// - Parameters:
+    ///   - ref: The mock reference to check calls for.
+    func hasCalled<Arguments, Result>(
+        _ ref: AsyncThrowingMockReference<Arguments, Result>,
+        numberOfTimes: Int
+    ) -> Bool {
+        calls(to: ref).count == numberOfTimes
+    }
+
+    /// Check if an async mock reference has been called.
+    ///
+    /// For this function to return `true` the actual number
+    /// of calls must match the provided `numberOfCalls`.
+    ///
+    /// - Parameters:
+    ///   - refKeyPath: A key path to the mock reference to check calls for.
+    func hasCalled<Arguments, Result>(
+        _ refKeyPath: KeyPath<Self, AsyncThrowingMockReference<Arguments, Result>>,
         numberOfTimes: Int
     ) -> Bool {
         hasCalled(self[keyPath: refKeyPath], numberOfTimes: numberOfTimes)

--- a/Sources/MockingKit/Mockable+Register.swift
+++ b/Sources/MockingKit/Mockable+Register.swift
@@ -57,4 +57,48 @@ public extension Mockable {
     ) {
         registerResult(for: self[keyPath: refKeyPath], result: result)
     }
+
+    /// Register a result value for a mock reference.
+    /// - Parameters:
+    ///   - ref: The mock reference to register a result for.
+    ///   - result: What to return when the function is called.
+    func registerResult<Arguments, Result>(
+        for ref: ThrowingMockReference<Arguments, Result>,
+        result: @escaping (Arguments) throws -> Result
+    ) {
+        mock.registeredResults[ref.id] = result
+    }
+
+    /// Register a result value for a mock reference.
+    /// - Parameters:
+    ///   - refKeyPath: A key path to the mock reference to register a result for.
+    ///   - result: What to return when the function is called.
+    func registerResult<Arguments, Result>(
+        for refKeyPath: KeyPath<Self, ThrowingMockReference<Arguments, Result>>,
+        result: @escaping (Arguments) throws -> Result
+    ) {
+        registerResult(for: self[keyPath: refKeyPath], result: result)
+    }
+
+    /// Register a result value for an async mock reference.
+    /// - Parameters:
+    ///   - ref: The mock reference to register a result for.
+    ///   - result: What to return when the function is called.
+    func registerResult<Arguments, Result>(
+        for ref: AsyncThrowingMockReference<Arguments, Result>,
+        result: @escaping (Arguments) async throws -> Result
+    ) {
+        mock.registeredResults[ref.id] = result
+    }
+
+    /// Register a result value for an async mock reference.
+    /// - Parameters:
+    ///   - refKeyPath: A key path to the mock reference to register a result for.
+    ///   - result: What to return when the function is called.
+    func registerResult<Arguments, Result>(
+        for refKeyPath: KeyPath<Self, AsyncThrowingMockReference<Arguments, Result>>,
+        result: @escaping (Arguments) async throws -> Result
+    ) {
+        registerResult(for: self[keyPath: refKeyPath], result: result)
+    }
 }

--- a/Sources/MockingKit/Mockable+Reset.swift
+++ b/Sources/MockingKit/Mockable+Reset.swift
@@ -54,4 +54,44 @@ public extension Mockable {
     ) {
         resetCalls(to: self[keyPath: refKeyPath])
     }
+
+    /// Reset all registered calls for a mock reference.
+    ///
+    /// - Parameters:
+    ///   - ref: The mock reference to reset any calls for.
+    func resetCalls<Arguments, Result>(
+        to ref: ThrowingMockReference<Arguments, Result>
+    ) {
+        mock.registeredCalls[ref.id] = []
+    }
+
+    /// Reset all registered calls for a mock reference.
+    ///
+    /// - Parameters:
+    ///   - refKeyPath: A key path to the mock reference to reset any calls for.
+    func resetCalls<Arguments, Result>(
+        to refKeyPath: KeyPath<Self, ThrowingMockReference<Arguments, Result>>
+    ) {
+        resetCalls(to: self[keyPath: refKeyPath])
+    }
+
+    /// Reset all registered calls for a mock reference.
+    ///
+    /// - Parameters:
+    ///   - ref: The mock reference to reset any calls for.
+    func resetCalls<Arguments, Result>(
+        to ref: AsyncThrowingMockReference<Arguments, Result>
+    ) {
+        mock.registeredCalls[ref.id] = []
+    }
+
+    /// Reset all registered calls for a mock reference.
+    ///
+    /// - Parameters:
+    ///   - refKeyPath: A key path to the mock reference to reset any calls for.
+    func resetCalls<Arguments, Result>(
+        to refKeyPath: KeyPath<Self, AsyncThrowingMockReference<Arguments, Result>>
+    ) {
+        resetCalls(to: self[keyPath: refKeyPath])
+    }
 }

--- a/Sources/MockingKit/Mockable.swift
+++ b/Sources/MockingKit/Mockable.swift
@@ -52,7 +52,27 @@ extension Mockable {
             mock.registeredCalls[ref.id] = calls + [call]
         }
     }
-    
+
+    func registerCall<Arguments, Result>(
+        _ call: MockCall<Arguments, Result>,
+        for ref: ThrowingMockReference<Arguments, Result>
+    ) {
+        mock.registeredCallsLock.withLock {
+            let calls = mock.registeredCalls[ref.id] ?? []
+            mock.registeredCalls[ref.id] = calls + [call]
+        }
+    }
+
+    func registerCall<Arguments, Result>(
+        _ call: MockCall<Arguments, Result>,
+        for ref: AsyncThrowingMockReference<Arguments, Result>
+    ) {
+        mock.registeredCallsLock.withLock {
+            let calls = mock.registeredCalls[ref.id] ?? []
+            mock.registeredCalls[ref.id] = calls + [call]
+        }
+    }
+
     func registeredCalls<Arguments, Result>(
         for ref: MockReference<Arguments, Result>
     ) -> [MockCall<Arguments, Result>] {
@@ -64,6 +84,24 @@ extension Mockable {
 
     func registeredCalls<Arguments, Result>(
         for ref: AsyncMockReference<Arguments, Result>
+    ) -> [MockCall<Arguments, Result>] {
+        mock.registeredCallsLock.withLock {
+            let calls = mock.registeredCalls[ref.id]
+            return (calls as? [MockCall<Arguments, Result>]) ?? []
+        }
+    }
+
+    func registeredCalls<Arguments, Result>(
+        for ref: AsyncThrowingMockReference<Arguments, Result>
+    ) -> [MockCall<Arguments, Result>] {
+        mock.registeredCallsLock.withLock {
+            let calls = mock.registeredCalls[ref.id]
+            return (calls as? [MockCall<Arguments, Result>]) ?? []
+        }
+    }
+
+    func registeredCalls<Arguments, Result>(
+        for ref: ThrowingMockReference<Arguments, Result>
     ) -> [MockCall<Arguments, Result>] {
         mock.registeredCallsLock.withLock {
             let calls = mock.registeredCalls[ref.id]
@@ -86,6 +124,22 @@ extension Mockable {
         mock.registeredCallsLock.withLock {
             let result = mock.registeredResults[ref.id] as? (Arguments) async throws -> Result
             return result
+        }
+    }
+
+    func registeredResult<Arguments, Result>(
+        for ref: ThrowingMockReference<Arguments, Result>
+    ) -> ((Arguments) throws -> Result)? {
+        mock.registeredCallsLock.withLock {
+            mock.registeredResults[ref.id] as? (Arguments) throws -> Result
+        }
+    }
+
+    func registeredResult<Arguments, Result>(
+        for ref: AsyncThrowingMockReference<Arguments, Result>
+    ) -> ((Arguments) async throws -> Result)? {
+        mock.registeredCallsLock.withLock {
+            mock.registeredResults[ref.id] as? (Arguments) async throws -> Result
         }
     }
 }

--- a/Sources/MockingKit/ThrowingMockReference.swift
+++ b/Sources/MockingKit/ThrowingMockReference.swift
@@ -1,0 +1,20 @@
+//
+//  ThrowingMockReference.swift
+//  MockingKit
+//
+//  Created by Sebastiano Zane on 25/05/2026.
+//
+
+import Foundation
+
+/// This type can be used to create mock function references.
+public struct ThrowingMockReference<Arguments, Result>: Identifiable {
+
+    public init(_ function: @escaping (Arguments) throws -> Result) {
+        self.id = UUID()
+        self.function = function
+    }
+
+    public let id: UUID
+    public let function: (Arguments) throws -> Result
+}

--- a/Tests/MockingKitTests/AsyncThrowingMockReferenceTests.swift
+++ b/Tests/MockingKitTests/AsyncThrowingMockReferenceTests.swift
@@ -1,0 +1,366 @@
+//
+//  AsyncThrowingMockReferenceTests.swift
+//  MockingKit
+//
+//  Created by Sebastiano Zane on 25/05/2026.
+//
+
+import XCTest
+@testable import MockingKit
+
+private enum MockError: Error {
+    case someError
+}
+
+class AsyncThrowingMockReferenceTests: XCTestCase {
+
+    private lazy var mock = TestClass()
+
+    func testCanRegisterThrowingErrorsAsResult() async {
+        mock.registerResult(for: \.functionWithIntResultRef) {_,_ in throw MockError.someError }
+        mock.registerResult(for: \.functionWithStringResultRef) {_,_ in throw MockError.someError }
+        mock.registerResult(for: \.functionWithStructResultRef) {_,_ in throw MockError.someError }
+        mock.registerResult(for: \.functionWithClassResultRef) {_,_ in throw MockError.someError }
+        mock.registerResult(for: \.functionWithOptionalIntResultRef) {_,_ in throw MockError.someError }
+        mock.registerResult(for: \.functionWithOptionalStringResultRef) {_,_ in throw MockError.someError }
+        mock.registerResult(for: \.functionWithOptionalStructResultRef) {_,_ in throw MockError.someError }
+        mock.registerResult(for: \.functionWithOptionalClassResultRef) {_,_ in throw MockError.someError }
+        mock.registerResult(for: \.functionWithVoidResultRef) {_,_ in throw MockError.someError }
+
+        await assertThrowsAsyncError { try await mock.functionWithIntResult(arg1: "abc", arg2: 123) }
+        await assertThrowsAsyncError { try await mock.functionWithStringResult(arg1: "abc", arg2: 123) }
+        await assertThrowsAsyncError { try await mock.functionWithStructResult(arg1: "abc", arg2: 123) }
+        await assertThrowsAsyncError { try await mock.functionWithClassResult(arg1: "abc", arg2: 123) }
+        await assertThrowsAsyncError { try await mock.functionWithOptionalIntResult(arg1: "abc", arg2: 123) }
+        await assertThrowsAsyncError { try await mock.functionWithOptionalStringResult(arg1: "abc", arg2: 123) }
+        await assertThrowsAsyncError { try await mock.functionWithOptionalStructResult(arg1: "abc", arg2: 123) }
+        await assertThrowsAsyncError { try await mock.functionWithOptionalClassResult(arg1: "abc", arg2: 123) }
+        await assertThrowsAsyncError { try await mock.functionWithVoidResult(arg1: "abc", arg2: 123) }
+    }
+
+    func testCanRegisterFunctionWithReferenceIdAsResult() {
+        let ref = mock.functionWithIntResultRef
+        mock.registerResult(for: ref) { _, int in int * 2 }
+        let obj = mock.mock.registeredResults[ref.id]
+        XCTAssertNotNil(obj)
+    }
+
+    func testCanCallFunctionWithNonOptionalResultAndDifferentResultTypes() async throws {
+        let user = User(name: "a user")
+        let thing = Thing(name: "a thing")
+
+        mock.registerResult(for: mock.functionWithIntResultRef) { _ in 123 }
+        mock.registerResult(for: mock.functionWithStringResultRef) { _ in "a string" }
+        mock.registerResult(for: \.functionWithStructResultRef) { _ in user }
+        mock.registerResult(for: \.functionWithClassResultRef) { _ in thing }
+
+        let intResult = try await mock.functionWithIntResult(arg1: "abc", arg2: 123)
+        let stringResult = try await mock.functionWithStringResult(arg1: "abc", arg2: 123)
+        let structResult = try await mock.functionWithStructResult(arg1: "abc", arg2: 123)
+        let classResult = try await mock.functionWithClassResult(arg1: "abc", arg2: 123)
+
+        XCTAssertEqual(intResult, 123)
+        XCTAssertEqual(stringResult, "a string")
+        XCTAssertEqual(structResult, user)
+        XCTAssertTrue(classResult === thing)
+    }
+
+    func testCanCallFunctionWithNonOptionalResultAndDifferentReturnValuesForDifferentArgumentValues() async throws {
+        mock.registerResult(for: mock.functionWithIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: \.functionWithStringResultRef) { arg1, _ in arg1 }
+
+        let intResult = try await mock.functionWithIntResult(arg1: "abc", arg2: 123)
+        let intResult2 = try await mock.functionWithIntResult(arg1: "abc", arg2: 456)
+        let stringResult = try await mock.functionWithStringResult(arg1: "abc", arg2: 123)
+        let stringResult2 = try await mock.functionWithStringResult(arg1: "def", arg2: 123)
+
+        XCTAssertEqual(intResult, 123)
+        XCTAssertEqual(intResult2, 456)
+        XCTAssertEqual(stringResult, "abc")
+        XCTAssertEqual(stringResult2, "def")
+    }
+
+    func testCallingFunctionWithNonOptionalResultRegistersCalls() async throws {
+        mock.registerResult(for: mock.functionWithIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: \.functionWithStringResultRef) { arg1, _ in arg1 }
+
+        _ = try await mock.functionWithIntResult(arg1: "abc", arg2: 123)
+        _ = try await mock.functionWithIntResult(arg1: "abc", arg2: 456)
+        _ = try await mock.functionWithIntResult(arg1: "abc", arg2: 789)
+        _ = try await mock.functionWithStringResult(arg1: "abc", arg2: 123)
+        _ = try await mock.functionWithStringResult(arg1: "def", arg2: 123)
+
+        let intCalls = mock.calls(to: mock.functionWithIntResultRef)
+        let strCalls = mock.calls(to: mock.functionWithStringResultRef)
+
+        XCTAssertEqual(intCalls.count, 3)
+        XCTAssertEqual(strCalls.count, 2)
+        XCTAssertEqual(intCalls[0].arguments.0, "abc")
+        XCTAssertEqual(intCalls[0].arguments.1, 123)
+        XCTAssertEqual(intCalls[1].arguments.0, "abc")
+        XCTAssertEqual(intCalls[1].arguments.1, 456)
+        XCTAssertEqual(intCalls[2].arguments.0, "abc")
+        XCTAssertEqual(intCalls[2].arguments.1, 789)
+        XCTAssertEqual(strCalls[0].arguments.0, "abc")
+        XCTAssertEqual(strCalls[0].arguments.1, 123)
+        XCTAssertEqual(strCalls[1].arguments.0, "def")
+        XCTAssertEqual(strCalls[1].arguments.1, 123)
+    }
+
+    func testCallingFunctionWithOptionalResultDoesNotFailWithPreconditionFailureIfNoResultIsRegistered() async throws {
+        let intResult = try await mock.functionWithOptionalIntResult(arg1: "abc", arg2: 123)
+        let stringResult = try await mock.functionWithOptionalStringResult(arg1: "abc", arg2: 123)
+        let structResult = try await mock.functionWithOptionalStructResult(arg1: "abc", arg2: 123)
+        let classResult = try await mock.functionWithOptionalClassResult(arg1: "abc", arg2: 123)
+
+        XCTAssertNil(intResult)
+        XCTAssertNil(stringResult)
+        XCTAssertNil(structResult)
+        XCTAssertNil(classResult)
+    }
+
+    func testCallingFunctionWithOptionalResultSupportsDifferentResultTypes() async throws {
+        let user = User(name: "a user")
+        let thing = Thing(name: "a thing")
+
+        mock.registerResult(for: mock.functionWithOptionalIntResultRef) { _ in 123 }
+        mock.registerResult(for: mock.functionWithOptionalStringResultRef) { _ in "a string" }
+        mock.registerResult(for: \.functionWithOptionalStructResultRef) { _ in user }
+        mock.registerResult(for: \.functionWithOptionalClassResultRef) { _ in thing }
+
+        let intResult = try await mock.functionWithOptionalIntResult(arg1: "abc", arg2: 123)
+        let stringResult = try await mock.functionWithOptionalStringResult(arg1: "abc", arg2: 123)
+        let structResult = try await mock.functionWithOptionalStructResult(arg1: "abc", arg2: 123)
+        let classResult = try await mock.functionWithOptionalClassResult(arg1: "abc", arg2: 123)
+
+        XCTAssertEqual(intResult, 123)
+        XCTAssertEqual(stringResult, "a string")
+        XCTAssertEqual(structResult, user)
+        XCTAssertTrue(classResult === thing)
+    }
+
+    func testCallingFunctionWithOptionalResultCanRegisterDifferentReturnValuesForDifferentArgumentValues() async throws {
+        mock.registerResult(for: mock.functionWithOptionalIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: \.functionWithOptionalStringResultRef) { arg1, _ in arg1 }
+
+        let intResult = try await mock.functionWithOptionalIntResult(arg1: "abc", arg2: 123)
+        let int2Result = try await mock.functionWithOptionalIntResult(arg1: "abc", arg2: 456)
+        let stringResult = try await mock.functionWithOptionalStringResult(arg1: "abc", arg2: 123)
+        let string2Result = try await mock.functionWithOptionalStringResult(arg1: "def", arg2: 123)
+
+        XCTAssertEqual(intResult, 123)
+        XCTAssertEqual(int2Result, 456)
+        XCTAssertEqual(stringResult, "abc")
+        XCTAssertEqual(string2Result, "def")
+    }
+
+    func testCallingFunctionWithOptionalResultRegistersCalls() async throws {
+        mock.registerResult(for: mock.functionWithOptionalIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: \.functionWithOptionalStringResultRef) { arg1, _ in arg1 }
+
+        _ = try await mock.functionWithOptionalIntResult(arg1: "abc", arg2: 123)
+        _ = try await mock.functionWithOptionalIntResult(arg1: "abc", arg2: 456)
+        _ = try await mock.functionWithOptionalIntResult(arg1: "abc", arg2: 789)
+        _ = try await mock.functionWithOptionalStringResult(arg1: "abc", arg2: 123)
+        _ = try await mock.functionWithOptionalStringResult(arg1: "def", arg2: 123)
+
+        let intCalls = mock.calls(to: mock.functionWithOptionalIntResultRef)
+        let strCalls = mock.calls(to: \.functionWithOptionalStringResultRef)
+
+        XCTAssertEqual(intCalls.count, 3)
+        XCTAssertEqual(strCalls.count, 2)
+        XCTAssertEqual(intCalls[0].arguments.0, "abc")
+        XCTAssertEqual(intCalls[0].arguments.1, 123)
+        XCTAssertEqual(intCalls[1].arguments.0, "abc")
+        XCTAssertEqual(intCalls[1].arguments.1, 456)
+        XCTAssertEqual(intCalls[2].arguments.0, "abc")
+        XCTAssertEqual(intCalls[2].arguments.1, 789)
+        XCTAssertEqual(strCalls[0].arguments.0, "abc")
+        XCTAssertEqual(strCalls[0].arguments.1, 123)
+        XCTAssertEqual(strCalls[1].arguments.0, "def")
+        XCTAssertEqual(strCalls[1].arguments.1, 123)
+    }
+
+    func testCallingFunctionWithFallbackReturnsDefaultValueIfNoValueIsRegistered() async throws {
+        let intResult = try await mock.call(mock.functionWithIntResultRef, args: ("abc", 123), fallback: 456)
+        let stringResult = try await mock.call(mock.functionWithStringResultRef, args: ("abc", 123), fallback: "def")
+
+        XCTAssertEqual(intResult, 456)
+        XCTAssertEqual(stringResult, "def")
+    }
+
+    func testCallingFunctionWithFallbackReturnsRegisteredValueIfAValueIsRegistered() async throws {
+        mock.registerResult(for: mock.functionWithIntResultRef) { _ in 123 }
+        mock.registerResult(for: \.functionWithStringResultRef) { _ in "a string" }
+
+        let intResult = try await mock.call(mock.functionWithIntResultRef, args: ("abc", 123), fallback: 456)
+        let stringResult = try await mock.call(mock.functionWithStringResultRef, args: ("abc", 123), fallback: "def")
+
+        XCTAssertEqual(intResult, 123)
+        XCTAssertEqual(stringResult, "a string")
+    }
+
+    func testCallingFunctionWithVoidResultDoesNotFailWithPreconditionFailureIfNoResultIsRegistered() async throws {
+        try await mock.functionWithVoidResult(arg1: "abc", arg2: 123)
+    }
+
+    func testCallingFunctionWithVoidResultRegistersCalls() async throws {
+        mock.registerResult(for: mock.functionWithVoidResultRef) { _, _ in }
+        mock.registerResult(for: mock.functionWithOptionalIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: \.functionWithOptionalStringResultRef) { arg1, _ in arg1 }
+
+        try await mock.functionWithVoidResult(arg1: "abc", arg2: 123)
+        try await mock.functionWithVoidResult(arg1: "abc", arg2: 456)
+        try await mock.functionWithVoidResult(arg1: "abc", arg2: 789)
+
+        let calls = mock.calls(to: mock.functionWithVoidResultRef)
+
+        XCTAssertEqual(calls.count, 3)
+        XCTAssertEqual(calls[0].arguments.0, "abc")
+        XCTAssertEqual(calls[0].arguments.1, 123)
+        XCTAssertEqual(calls[1].arguments.0, "abc")
+        XCTAssertEqual(calls[1].arguments.1, 456)
+        XCTAssertEqual(calls[2].arguments.0, "abc")
+        XCTAssertEqual(calls[2].arguments.1, 789)
+    }
+
+    func testInspectingCallsRegistersAllCalls() async throws {
+        mock.registerResult(for: mock.functionWithVoidResultRef) { _, _ in }
+
+        try await mock.functionWithVoidResult(arg1: "abc", arg2: 123)
+        try await mock.functionWithVoidResult(arg1: "abc", arg2: 456)
+        try await mock.functionWithVoidResult(arg1: "abc", arg2: 789)
+
+        let calls = mock.calls(to: mock.functionWithVoidResultRef)
+
+        XCTAssertEqual(calls.count, 3)
+    }
+
+    func testInspectingCallsCanVerifyIfAtLeastOneCallHasBeenMade() async throws {
+        mock.registerResult(for: mock.functionWithVoidResultRef) { _, _ in }
+
+        XCTAssertFalse(mock.hasCalled(mock.functionWithVoidResultRef))
+        try await mock.functionWithVoidResult(arg1: "abc", arg2: 123)
+        XCTAssertTrue(mock.hasCalled(\.functionWithVoidResultRef))
+        try await mock.functionWithVoidResult(arg1: "abc", arg2: 456)
+        XCTAssertTrue(mock.hasCalled(mock.functionWithVoidResultRef))
+    }
+
+    func testInspectingCallsCanVerifyIfAnExactNumberOrCallsHaveBeenMade() async throws {
+        mock.registerResult(for: \.functionWithVoidResultRef) { _,_ in }
+
+        XCTAssertFalse(mock.hasCalled(mock.functionWithVoidResultRef, numberOfTimes: 2))
+        try await mock.functionWithVoidResult(arg1: "abc", arg2: 123)
+        XCTAssertFalse(mock.hasCalled(\.functionWithVoidResultRef, numberOfTimes: 2))
+        try await mock.functionWithVoidResult(arg1: "abc", arg2: 456)
+        XCTAssertTrue(mock.hasCalled(mock.functionWithVoidResultRef, numberOfTimes: 2))
+    }
+
+    func testResettingCallsCanResetAllCalls() async throws {
+        mock.registerResult(for: mock.functionWithIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: \.functionWithStringResultRef) { arg1, _ in arg1 }
+
+        _ = try await mock.functionWithIntResult(arg1: "abc", arg2: 123)
+        _ = try await mock.functionWithStringResult(arg1: "abc", arg2: 123)
+
+        mock.resetCalls()
+
+        XCTAssertFalse(mock.hasCalled(mock.functionWithIntResultRef))
+        XCTAssertFalse(mock.hasCalled(\.functionWithStringResultRef))
+    }
+
+    func testResettingCalls_canResetAllCallsForACertainFunction() async throws {
+        mock.registerResult(for: mock.functionWithIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: mock.functionWithStringResultRef) { arg1, _ in arg1 }
+
+        _ = try await mock.functionWithIntResult(arg1: "abc", arg2: 123)
+        _ = try await mock.functionWithStringResult(arg1: "abc", arg2: 123)
+
+        mock.resetCalls(to: mock.functionWithIntResultRef)
+
+        XCTAssertFalse(mock.hasCalled(mock.functionWithIntResultRef))
+        XCTAssertTrue(mock.hasCalled(\.functionWithStringResultRef))
+    }
+
+    func testMultiThreadedAccess_doesNotCorruptState() async throws {
+        let expectation = XCTestExpectation()
+        expectation.expectedFulfillmentCount = 2
+        let testMock = TestClass()
+        testMock.registerResult(for: testMock.functionWithVoidResultRef) { _, _ in }
+
+        Task {
+            for index in 0..<100 {
+                try await testMock.functionWithVoidResult(arg1: "Test", arg2: index)
+            }
+            expectation.fulfill()
+        }
+
+        Task {
+            for _ in 0..<100 {
+                _ = testMock.hasCalled(\.functionWithIntResultRef)
+            }
+            expectation.fulfill()
+        }
+
+        await fulfillment(of: [expectation])
+    }
+}
+
+private final class TestClass: Mock, @unchecked Sendable {
+    lazy var functionWithIntResultRef = AsyncThrowingMockReference(functionWithIntResult)
+    lazy var functionWithStringResultRef = AsyncThrowingMockReference(functionWithStringResult)
+    lazy var functionWithStructResultRef = AsyncThrowingMockReference(functionWithStructResult)
+    lazy var functionWithClassResultRef = AsyncThrowingMockReference(functionWithClassResult)
+    lazy var functionWithOptionalIntResultRef = AsyncThrowingMockReference(functionWithOptionalIntResult)
+    lazy var functionWithOptionalStringResultRef = AsyncThrowingMockReference(functionWithOptionalStringResult)
+    lazy var functionWithOptionalStructResultRef = AsyncThrowingMockReference(functionWithOptionalStructResult)
+    lazy var functionWithOptionalClassResultRef = AsyncThrowingMockReference(functionWithOptionalClassResult)
+    lazy var functionWithVoidResultRef = AsyncThrowingMockReference(functionWithVoidResult)
+
+    func functionWithIntResult(arg1: String, arg2: Int) async throws -> Int {
+        try await call(functionWithIntResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithStringResult(arg1: String, arg2: Int) async throws -> String {
+        try await call(functionWithStringResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithStructResult(arg1: String, arg2: Int) async throws -> User {
+        try await call(functionWithStructResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithClassResult(arg1: String, arg2: Int) async throws -> Thing {
+        try await call(functionWithClassResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithOptionalIntResult(arg1: String, arg2: Int) async throws -> Int? {
+        try await call(functionWithOptionalIntResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithOptionalStringResult(arg1: String, arg2: Int) async throws -> String? {
+        try await call(functionWithOptionalStringResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithOptionalStructResult(arg1: String, arg2: Int) async throws -> User? {
+        try await call(functionWithOptionalStructResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithOptionalClassResult(arg1: String, arg2: Int) async throws -> Thing? {
+        try await call(functionWithOptionalClassResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithVoidResult(arg1: String, arg2: Int) async throws {
+        try await call(functionWithVoidResultRef, args: (arg1, arg2))
+    }
+}
+
+private func assertThrowsAsyncError<T>(
+    _ expression: () async throws -> T,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    do {
+        _ = try await expression()
+        XCTFail("Expected expression to throw an error", file: file, line: line)
+    } catch {}
+}

--- a/Tests/MockingKitTests/ThrowingMockReferenceTests.swift
+++ b/Tests/MockingKitTests/ThrowingMockReferenceTests.swift
@@ -1,0 +1,355 @@
+//
+//  ThrowingMockReferenceTests.swift
+//  MockingKit
+//
+//  Created by Sebastiano Zane on 25/05/2026.
+//
+
+import XCTest
+@testable import MockingKit
+
+private enum MockError: Error {
+    case someError
+}
+
+class ThrowingMockReferenceTests: XCTestCase {
+
+    private lazy var mock = TestClass()
+
+    func testCanRegisterThrowingErrorsAsResult() {
+        mock.registerResult(for: \.functionWithIntResultRef) {_,_ in throw MockError.someError }
+        mock.registerResult(for: \.functionWithStringResultRef) {_,_ in throw MockError.someError }
+        mock.registerResult(for: \.functionWithStructResultRef) {_,_ in throw MockError.someError }
+        mock.registerResult(for: \.functionWithClassResultRef) {_,_ in throw MockError.someError }
+        mock.registerResult(for: \.functionWithOptionalIntResultRef) {_,_ in throw MockError.someError }
+        mock.registerResult(for: \.functionWithOptionalStringResultRef) {_,_ in throw MockError.someError }
+        mock.registerResult(for: \.functionWithOptionalStructResultRef) {_,_ in throw MockError.someError }
+        mock.registerResult(for: \.functionWithOptionalClassResultRef) {_,_ in throw MockError.someError }
+        mock.registerResult(for: \.functionWithVoidResultRef) {_,_ in throw MockError.someError }
+
+        XCTAssertThrowsError(try mock.functionWithIntResult(arg1: "abc", arg2: 123))
+        XCTAssertThrowsError(try mock.functionWithStringResult(arg1: "abc", arg2: 123))
+        XCTAssertThrowsError(try mock.functionWithStructResult(arg1: "abc", arg2: 123))
+        XCTAssertThrowsError(try mock.functionWithClassResult(arg1: "abc", arg2: 123))
+        XCTAssertThrowsError(try mock.functionWithOptionalIntResult(arg1: "abc", arg2: 123))
+        XCTAssertThrowsError(try mock.functionWithOptionalStringResult(arg1: "abc", arg2: 123))
+        XCTAssertThrowsError(try mock.functionWithOptionalStructResult(arg1: "abc", arg2: 123))
+        XCTAssertThrowsError(try mock.functionWithOptionalClassResult(arg1: "abc", arg2: 123))
+        XCTAssertThrowsError(try mock.functionWithVoidResult(arg1: "abc", arg2: 123))
+    }
+
+    func testCanRegisterFunctionWithReferenceIdAsResult() {
+        let ref = mock.functionWithIntResultRef
+        mock.registerResult(for: ref) { _, int in int * 2 }
+        let obj = mock.mock.registeredResults[ref.id]
+        XCTAssertNotNil(obj)
+    }
+
+    func testCanCallFunctionWithNonOptionalResultAndDifferentResultTypes() throws {
+        let user = User(name: "a user")
+        let thing = Thing(name: "a thing")
+
+        mock.registerResult(for: mock.functionWithIntResultRef) { _ in 123 }
+        mock.registerResult(for: mock.functionWithStringResultRef) { _ in "a string" }
+        mock.registerResult(for: \.functionWithStructResultRef) { _ in user }
+        mock.registerResult(for: \.functionWithClassResultRef) { _ in thing }
+
+        let intResult = try mock.functionWithIntResult(arg1: "abc", arg2: 123)
+        let stringResult = try mock.functionWithStringResult(arg1: "abc", arg2: 123)
+        let structResult = try mock.functionWithStructResult(arg1: "abc", arg2: 123)
+        let classResult = try mock.functionWithClassResult(arg1: "abc", arg2: 123)
+
+        XCTAssertEqual(intResult, 123)
+        XCTAssertEqual(stringResult, "a string")
+        XCTAssertEqual(structResult, user)
+        XCTAssertTrue(classResult === thing)
+    }
+
+    func testCanCallFunctionWithNonOptionalResultAndDifferentReturnValuesForDifferentArgumentValues() throws {
+        mock.registerResult(for: mock.functionWithIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: \.functionWithStringResultRef) { arg1, _ in arg1 }
+
+        let intResult = try mock.functionWithIntResult(arg1: "abc", arg2: 123)
+        let intResult2 = try mock.functionWithIntResult(arg1: "abc", arg2: 456)
+        let stringResult = try mock.functionWithStringResult(arg1: "abc", arg2: 123)
+        let stringResult2 = try mock.functionWithStringResult(arg1: "def", arg2: 123)
+
+        XCTAssertEqual(intResult, 123)
+        XCTAssertEqual(intResult2, 456)
+        XCTAssertEqual(stringResult, "abc")
+        XCTAssertEqual(stringResult2, "def")
+    }
+
+    func testCallingFunctionWithNonOptionalResultRegistersCalls() throws {
+        mock.registerResult(for: mock.functionWithIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: \.functionWithStringResultRef) { arg1, _ in arg1 }
+
+        _ = try mock.functionWithIntResult(arg1: "abc", arg2: 123)
+        _ = try mock.functionWithIntResult(arg1: "abc", arg2: 456)
+        _ = try mock.functionWithIntResult(arg1: "abc", arg2: 789)
+        _ = try mock.functionWithStringResult(arg1: "abc", arg2: 123)
+        _ = try mock.functionWithStringResult(arg1: "def", arg2: 123)
+
+        let intCalls = mock.calls(to: mock.functionWithIntResultRef)
+        let strCalls = mock.calls(to: mock.functionWithStringResultRef)
+
+        XCTAssertEqual(intCalls.count, 3)
+        XCTAssertEqual(strCalls.count, 2)
+        XCTAssertEqual(intCalls[0].arguments.0, "abc")
+        XCTAssertEqual(intCalls[0].arguments.1, 123)
+        XCTAssertEqual(intCalls[1].arguments.0, "abc")
+        XCTAssertEqual(intCalls[1].arguments.1, 456)
+        XCTAssertEqual(intCalls[2].arguments.0, "abc")
+        XCTAssertEqual(intCalls[2].arguments.1, 789)
+        XCTAssertEqual(strCalls[0].arguments.0, "abc")
+        XCTAssertEqual(strCalls[0].arguments.1, 123)
+        XCTAssertEqual(strCalls[1].arguments.0, "def")
+        XCTAssertEqual(strCalls[1].arguments.1, 123)
+    }
+
+    func testCallingFunctionWithOptionalResultDoesNotFailWithPreconditionFailureIfNoResultIsRegistered() throws {
+        let intResult = try mock.functionWithOptionalIntResult(arg1: "abc", arg2: 123)
+        let stringResult = try mock.functionWithOptionalStringResult(arg1: "abc", arg2: 123)
+        let structResult = try mock.functionWithOptionalStructResult(arg1: "abc", arg2: 123)
+        let classResult = try mock.functionWithOptionalClassResult(arg1: "abc", arg2: 123)
+
+        XCTAssertNil(intResult)
+        XCTAssertNil(stringResult)
+        XCTAssertNil(structResult)
+        XCTAssertNil(classResult)
+    }
+
+    func testCallingFunctionWithOptionalResultSupportsDifferentResultTypes() throws {
+        let user = User(name: "a user")
+        let thing = Thing(name: "a thing")
+
+        mock.registerResult(for: mock.functionWithOptionalIntResultRef) { _ in 123 }
+        mock.registerResult(for: mock.functionWithOptionalStringResultRef) { _ in "a string" }
+        mock.registerResult(for: \.functionWithOptionalStructResultRef) { _ in user }
+        mock.registerResult(for: \.functionWithOptionalClassResultRef) { _ in thing }
+
+        let intResult = try mock.functionWithOptionalIntResult(arg1: "abc", arg2: 123)
+        let stringResult = try mock.functionWithOptionalStringResult(arg1: "abc", arg2: 123)
+        let structResult = try mock.functionWithOptionalStructResult(arg1: "abc", arg2: 123)
+        let classResult = try mock.functionWithOptionalClassResult(arg1: "abc", arg2: 123)
+
+        XCTAssertEqual(intResult, 123)
+        XCTAssertEqual(stringResult, "a string")
+        XCTAssertEqual(structResult, user)
+        XCTAssertTrue(classResult === thing)
+    }
+
+    func testCallingFunctionWithOptionalResultCanRegisterDifferentReturnValuesForDifferentArgumentValues() throws {
+        mock.registerResult(for: mock.functionWithOptionalIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: \.functionWithOptionalStringResultRef) { arg1, _ in arg1 }
+
+        let intResult = try mock.functionWithOptionalIntResult(arg1: "abc", arg2: 123)
+        let int2Result = try mock.functionWithOptionalIntResult(arg1: "abc", arg2: 456)
+        let stringResult = try mock.functionWithOptionalStringResult(arg1: "abc", arg2: 123)
+        let string2Result = try mock.functionWithOptionalStringResult(arg1: "def", arg2: 123)
+
+        XCTAssertEqual(intResult, 123)
+        XCTAssertEqual(int2Result, 456)
+        XCTAssertEqual(stringResult, "abc")
+        XCTAssertEqual(string2Result, "def")
+    }
+
+    func testCallingFunctionWithOptionalResultRegistersCalls() throws {
+        mock.registerResult(for: mock.functionWithOptionalIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: \.functionWithOptionalStringResultRef) { arg1, _ in arg1 }
+
+        _ = try mock.functionWithOptionalIntResult(arg1: "abc", arg2: 123)
+        _ = try mock.functionWithOptionalIntResult(arg1: "abc", arg2: 456)
+        _ = try mock.functionWithOptionalIntResult(arg1: "abc", arg2: 789)
+        _ = try mock.functionWithOptionalStringResult(arg1: "abc", arg2: 123)
+        _ = try mock.functionWithOptionalStringResult(arg1: "def", arg2: 123)
+
+        let intCalls = mock.calls(to: mock.functionWithOptionalIntResultRef)
+        let strCalls = mock.calls(to: \.functionWithOptionalStringResultRef)
+
+        XCTAssertEqual(intCalls.count, 3)
+        XCTAssertEqual(strCalls.count, 2)
+        XCTAssertEqual(intCalls[0].arguments.0, "abc")
+        XCTAssertEqual(intCalls[0].arguments.1, 123)
+        XCTAssertEqual(intCalls[1].arguments.0, "abc")
+        XCTAssertEqual(intCalls[1].arguments.1, 456)
+        XCTAssertEqual(intCalls[2].arguments.0, "abc")
+        XCTAssertEqual(intCalls[2].arguments.1, 789)
+        XCTAssertEqual(strCalls[0].arguments.0, "abc")
+        XCTAssertEqual(strCalls[0].arguments.1, 123)
+        XCTAssertEqual(strCalls[1].arguments.0, "def")
+        XCTAssertEqual(strCalls[1].arguments.1, 123)
+    }
+
+    func testCallingFunctionWithFallbackReturnsDefaultValueIfNoValueIsRegistered() throws {
+        let intResult = try mock.call(mock.functionWithIntResultRef, args: ("abc", 123), fallback: 456)
+        let stringResult = try mock.call(mock.functionWithStringResultRef, args: ("abc", 123), fallback: "def")
+
+        XCTAssertEqual(intResult, 456)
+        XCTAssertEqual(stringResult, "def")
+    }
+
+    func testCallingFunctionWithFallbackReturnsRegisteredValueIfAValueIsRegistered() throws {
+        mock.registerResult(for: mock.functionWithIntResultRef) { _ in 123 }
+        mock.registerResult(for: \.functionWithStringResultRef) { _ in "a string" }
+
+        let intResult = try mock.call(mock.functionWithIntResultRef, args: ("abc", 123), fallback: 456)
+        let stringResult = try mock.call(mock.functionWithStringResultRef, args: ("abc", 123), fallback: "def")
+
+        XCTAssertEqual(intResult, 123)
+        XCTAssertEqual(stringResult, "a string")
+    }
+
+    func testCallingFunctionWithVoidResultDoesNotFailWithPreconditionFailureIfNoResultIsRegistered() throws {
+        try mock.functionWithVoidResult(arg1: "abc", arg2: 123)
+    }
+
+    func testCallingFunctionWithVoidResultRegistersCalls() throws {
+        mock.registerResult(for: mock.functionWithVoidResultRef) { _, _ in }
+        mock.registerResult(for: mock.functionWithOptionalIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: \.functionWithOptionalStringResultRef) { arg1, _ in arg1 }
+
+        try mock.functionWithVoidResult(arg1: "abc", arg2: 123)
+        try mock.functionWithVoidResult(arg1: "abc", arg2: 456)
+        try mock.functionWithVoidResult(arg1: "abc", arg2: 789)
+
+        let calls = mock.calls(to: mock.functionWithVoidResultRef)
+
+        XCTAssertEqual(calls.count, 3)
+        XCTAssertEqual(calls[0].arguments.0, "abc")
+        XCTAssertEqual(calls[0].arguments.1, 123)
+        XCTAssertEqual(calls[1].arguments.0, "abc")
+        XCTAssertEqual(calls[1].arguments.1, 456)
+        XCTAssertEqual(calls[2].arguments.0, "abc")
+        XCTAssertEqual(calls[2].arguments.1, 789)
+    }
+
+    func testInspectingCallsRegistersAllCalls() throws {
+        mock.registerResult(for: mock.functionWithVoidResultRef) { _, _ in }
+
+        try mock.functionWithVoidResult(arg1: "abc", arg2: 123)
+        try mock.functionWithVoidResult(arg1: "abc", arg2: 456)
+        try mock.functionWithVoidResult(arg1: "abc", arg2: 789)
+
+        let calls = mock.calls(to: mock.functionWithVoidResultRef)
+
+        XCTAssertEqual(calls.count, 3)
+    }
+
+    func testInspectingCallsCanVerifyIfAtLeastOneCallHasBeenMade() throws {
+        mock.registerResult(for: mock.functionWithVoidResultRef) { _, _ in }
+
+        XCTAssertFalse(mock.hasCalled(mock.functionWithVoidResultRef))
+        try mock.functionWithVoidResult(arg1: "abc", arg2: 123)
+        XCTAssertTrue(mock.hasCalled(\.functionWithVoidResultRef))
+        try mock.functionWithVoidResult(arg1: "abc", arg2: 456)
+        XCTAssertTrue(mock.hasCalled(mock.functionWithVoidResultRef))
+    }
+
+    func testInspectingCallsCanVerifyIfAnExactNumberOrCallsHaveBeenMade() throws {
+        mock.registerResult(for: \.functionWithVoidResultRef) { _,_ in }
+
+        XCTAssertFalse(mock.hasCalled(mock.functionWithVoidResultRef, numberOfTimes: 2))
+        try mock.functionWithVoidResult(arg1: "abc", arg2: 123)
+        XCTAssertFalse(mock.hasCalled(\.functionWithVoidResultRef, numberOfTimes: 2))
+        try mock.functionWithVoidResult(arg1: "abc", arg2: 456)
+        XCTAssertTrue(mock.hasCalled(mock.functionWithVoidResultRef, numberOfTimes: 2))
+    }
+
+    func testResettingCallsCanResetAllCalls() throws {
+        mock.registerResult(for: mock.functionWithIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: \.functionWithStringResultRef) { arg1, _ in arg1 }
+
+        _ = try mock.functionWithIntResult(arg1: "abc", arg2: 123)
+        _ = try mock.functionWithStringResult(arg1: "abc", arg2: 123)
+
+        mock.resetCalls()
+
+        XCTAssertFalse(mock.hasCalled(mock.functionWithIntResultRef))
+        XCTAssertFalse(mock.hasCalled(\.functionWithStringResultRef))
+    }
+
+    func testResettingCalls_canResetAllCallsForACertainFunction() throws {
+        mock.registerResult(for: mock.functionWithIntResultRef) { _, arg2 in arg2 }
+        mock.registerResult(for: mock.functionWithStringResultRef) { arg1, _ in arg1 }
+
+        _ = try mock.functionWithIntResult(arg1: "abc", arg2: 123)
+        _ = try mock.functionWithStringResult(arg1: "abc", arg2: 123)
+
+        mock.resetCalls(to: mock.functionWithIntResultRef)
+
+        XCTAssertFalse(mock.hasCalled(mock.functionWithIntResultRef))
+        XCTAssertTrue(mock.hasCalled(\.functionWithStringResultRef))
+    }
+
+    func testMultiThreadedAccess_doesNotCorruptState() async throws {
+        let expectation = XCTestExpectation()
+        expectation.expectedFulfillmentCount = 2
+        let testMock = TestClass()
+        testMock.registerResult(for: testMock.functionWithVoidResultRef) { _, _ in }
+
+        Task {
+            for index in 0..<100 {
+                try testMock.functionWithVoidResult(arg1: "Test", arg2: index)
+            }
+            expectation.fulfill()
+        }
+
+        Task {
+            for _ in 0..<100 {
+                _ = testMock.hasCalled(\.functionWithIntResultRef)
+            }
+            expectation.fulfill()
+        }
+
+        await fulfillment(of: [expectation])
+    }
+}
+
+private final class TestClass: Mock, @unchecked Sendable {
+    lazy var functionWithIntResultRef = ThrowingMockReference(functionWithIntResult)
+    lazy var functionWithStringResultRef = ThrowingMockReference(functionWithStringResult)
+    lazy var functionWithStructResultRef = ThrowingMockReference(functionWithStructResult)
+    lazy var functionWithClassResultRef = ThrowingMockReference(functionWithClassResult)
+    lazy var functionWithOptionalIntResultRef = ThrowingMockReference(functionWithOptionalIntResult)
+    lazy var functionWithOptionalStringResultRef = ThrowingMockReference(functionWithOptionalStringResult)
+    lazy var functionWithOptionalStructResultRef = ThrowingMockReference(functionWithOptionalStructResult)
+    lazy var functionWithOptionalClassResultRef = ThrowingMockReference(functionWithOptionalClassResult)
+    lazy var functionWithVoidResultRef = ThrowingMockReference(functionWithVoidResult)
+
+    func functionWithIntResult(arg1: String, arg2: Int) throws -> Int {
+        try call(functionWithIntResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithStringResult(arg1: String, arg2: Int) throws -> String {
+        try call(functionWithStringResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithStructResult(arg1: String, arg2: Int) throws -> User {
+        try call(functionWithStructResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithClassResult(arg1: String, arg2: Int) throws -> Thing {
+        try call(functionWithClassResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithOptionalIntResult(arg1: String, arg2: Int) throws -> Int? {
+        try call(functionWithOptionalIntResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithOptionalStringResult(arg1: String, arg2: Int) throws -> String? {
+        try call(functionWithOptionalStringResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithOptionalStructResult(arg1: String, arg2: Int) throws -> User? {
+        try call(functionWithOptionalStructResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithOptionalClassResult(arg1: String, arg2: Int) throws -> Thing? {
+        try call(functionWithOptionalClassResultRef, args: (arg1, arg2))
+    }
+
+    func functionWithVoidResult(arg1: String, arg2: Int) throws {
+        try call(functionWithVoidResultRef, args: (arg1, arg2))
+    }
+}


### PR DESCRIPTION
This adds support for mocking functions that throw errors through two new reference types: `ThrowingMockReference` & `AsyncThrowingMockReference`.

While the current library supports mocking references that throw errors, the `try?` in the current implementation of `call` swallows errors thrown by the registered result and results in an erroneous precondition failure: `"You must register a result for '\(functionCall)' with `registerResult(for:)` before calling this function."`.

An alternative would have been to change the existing `call` APIs to propagate errors. That would have been a breaking change, since existing mock implementations would need to add `try`/`throws` handling when calling their mock references.

To guide users toward the new API, this also adds deprecation warnings when throwing functions or throwing result closures are used with the non-throwing reference types.